### PR TITLE
feat: add jpeg memory loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optimal-image"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrea Moretti <axyzxp@gmail.com>"]
 
 [badges]

--- a/src/optimal_image/dataclients/jpeg.rs
+++ b/src/optimal_image/dataclients/jpeg.rs
@@ -4,7 +4,7 @@ extern crate imgref;
 extern crate lodepng;
 extern crate rgb;
 
-use dataclients::{ImageDataResult, Loader};
+use dataclients::{ImageDataResult, Loader, MemoryLoader};
 use image::*;
 use rgb::RGBA;
 use std::path::Path;
@@ -24,6 +24,31 @@ impl Jpeg {
 impl Loader for Jpeg {
     fn load<P: AsRef<Path>>(&self, path: P) -> ImageDataResult<ImageError> {
         let image = image::open(path)?;
+        let (width, height) = image.dimensions();
+        let buffer = image
+            .to_rgba()
+            .pixels()
+            .map(|pixel| {
+                let [r, g, b, a] = pixel.to_rgba().data;
+                let rgba: RGBA<f32>;
+                // convert u8 (0/255) color values to (0-1) f32 ranges
+                rgba = RGBA {
+                    r: r as f32 / 255.0,
+                    g: g as f32 / 255.0,
+                    b: b as f32 / 255.0,
+                    a: a as f32 / 255.0,
+                };
+                rgba
+            })
+            .collect();
+
+        Ok(imgref::Img::new(buffer, width as usize, height as usize))
+    }
+}
+
+impl MemoryLoader for Jpeg {
+    fn load_from_memory(&self, buffer: &Vec<u8>) -> ImageDataResult<ImageError> {
+        let image = image::load_from_memory(&buffer)?;
         let (width, height) = image.dimensions();
         let buffer = image
             .to_rgba()

--- a/src/optimal_image/dataclients/mod.rs
+++ b/src/optimal_image/dataclients/mod.rs
@@ -15,5 +15,9 @@ pub trait Loader {
     fn load<P: AsRef<Path>>(&self, path: P) -> ImageDataResult<ImageError>;
 }
 
+pub trait MemoryLoader {
+    fn load_from_memory(&self, buffer: &Vec<u8>) -> ImageDataResult<ImageError>;
+}
+
 pub use self::jpeg::Jpeg;
 pub use self::png::Png;

--- a/src/optimal_image/lib.rs
+++ b/src/optimal_image/lib.rs
@@ -17,8 +17,8 @@ pub enum ImageFormat {
 
 #[derive(Debug, Clone)]
 pub struct EncodingConfig {
-    format: ImageFormat,
-    quality: u8,
+    pub format: ImageFormat,
+    pub quality: u8,
 }
 
 impl PartialOrd for EncodingConfig {
@@ -35,8 +35,8 @@ impl PartialEq for EncodingConfig {
 
 #[derive(Debug, Clone)]
 pub struct ImageConfig {
-    id: String,
-    encoding_config: EncodingConfig,
+    pub id: String,
+    pub encoding_config: EncodingConfig,
 }
 
 impl PartialOrd for ImageConfig {

--- a/src/optimal_image/search.rs
+++ b/src/optimal_image/search.rs
@@ -28,6 +28,23 @@ pub struct Search {
 }
 
 impl Search {
+    pub fn from_buffer(
+        path: String,
+        buf: &Vec<u8>,
+        options: SearchOptions,
+    ) -> Result<Search, Box<Error>> {
+        let dataclient = Jpeg::new();
+
+        let search = Search {
+            path: path,
+            image_data: dataclient.load_from_memory(&buf)?,
+            options: options,
+            result: None,
+        };
+
+        Ok(search)
+    }
+
     pub fn from_path(
         path: &Path,
         options: SearchOptions,
@@ -128,7 +145,8 @@ pub fn find_optimal_config<'a>(
             }
             Ordering::Equal
         })
-        .unwrap();
+        // fallback to lowest quality when threshold is too high
+        .unwrap_or(0);
 
     &config[index]
 }


### PR DESCRIPTION
@addityasingh 

- add memory loader for jpeg
- add from_buffer constructor for search so we can use a network downloaded buffer instead of a local image file.
- make search results public to be used to generate images
- fallback to lower quality when threshold is higher than lower level settings result